### PR TITLE
Supporting Personal Accounts

### DIFF
--- a/idonethis.php
+++ b/idonethis.php
@@ -1,8 +1,19 @@
 <?php
-$to      = str_replace(' ', '-', strtolower($argv[2])). '@team.idonethis.com';
-$subject = 'Re: '. $argv[2] . ' digest for ' . date("F d");
-$message = $argv[3];
+$argumentCount = count($argv);
+
 $sender = $argv[1];
 $headers = 'From: ' . $sender . "\r\n";
+
+if($argumentCount > 3) {
+  $to = str_replace(' ', '-', strtolower($argv[2])). '@team.idonethis.com';
+  $subjectIdentifier = $argv[2];
+  $message = $argv[3];
+} else {
+  $to = 'today@idonethis.com';
+  $subjectIdentifier = 'Personal';
+  $message = $argv[2];
+}
+
+$subject = 'Re: '. $subjectIdentifier . ' digest for ' . date("F d");
 
 mail($to, $subject, $message, $headers);


### PR DESCRIPTION
Currently, iDoneThis expects emails to personal calendars (free, non-team based) to be sent to today@idonethis.com instead of following the usual format ( [team-name]@team.idonethis.com). While iDoneThis has plans to support the latter format for personal calendars, this commit allows it to work with both. If only an email address and query are supplied, the extension will assume you want to send it to the personal email; otherwise, it returns to previous behavior.
